### PR TITLE
Use python struct for deserializing

### DIFF
--- a/src/lidar_visualizer/datasets/helipr.py
+++ b/src/lidar_visualizer/datasets/helipr.py
@@ -68,20 +68,16 @@ class HeLiPRDataset:
         if self.sequence_id == "Avia":
             self.format_string = "fffBBBL"
             self.index_intensity = None
-            self.index_time = 6
         elif self.sequence_id == "Aeva":
             self.format_string = "ffffflBf"
             self.format_string_no_intensity = "ffffflB"
             self.index_intensity = 7
-            self.index_time = 5
         elif self.sequence_id == "Ouster":
             self.format_string = "ffffIHHH"
             self.index_intensity = 3
-            self.index_time = 4
         elif self.sequence_id == "Velodyne":
             self.format_string = "ffffHf"
             self.index_intensity = 3
-            self.index_time = 5
         else:
             print("[ERROR] Unsupported LiDAR Type")
             sys.exit()
@@ -90,8 +86,7 @@ class HeLiPRDataset:
         return len(self.scan_files)
 
     def __getitem__(self, idx):
-        data = self.get_data(idx)
-        return self.read_point_cloud(data)
+        return self.read_point_cloud(idx)
 
     def get_data(self, idx: int):
         file_path = self.scan_files[idx]
@@ -114,7 +109,8 @@ class HeLiPRDataset:
         data = np.stack(list_lines)
         return data
 
-    def read_point_cloud(self, data: np.ndarray):
+    def read_point_cloud(self, idx: int):
+        data = self.get_data(idx)
         points = data[:, :3]
         scan = self.o3d.geometry.PointCloud()
         scan.points = self.o3d.utility.Vector3dVector(points)

--- a/src/lidar_visualizer/datasets/helipr.py
+++ b/src/lidar_visualizer/datasets/helipr.py
@@ -22,12 +22,12 @@
 # SOFTWARE.
 import importlib
 import os
+import struct
 import sys
 from pathlib import Path
 
 import natsort
 import numpy as np
-import struct
 
 from lidar_visualizer.datasets import supported_file_extensions
 

--- a/src/lidar_visualizer/datasets/helipr.py
+++ b/src/lidar_visualizer/datasets/helipr.py
@@ -67,17 +67,17 @@ class HeLiPRDataset:
         # Obtain the pointcloud reader for the given data folder
         if self.sequence_id == "Avia":
             self.format_string = "fffBBBL"
-            self.index_intensity = None
+            self.intensity_channel = None
         elif self.sequence_id == "Aeva":
             self.format_string = "ffffflBf"
             self.format_string_no_intensity = "ffffflB"
-            self.index_intensity = 7
+            self.intensity_channel = 7
         elif self.sequence_id == "Ouster":
             self.format_string = "ffffIHHH"
-            self.index_intensity = 3
+            self.intensity_channel = 3
         elif self.sequence_id == "Velodyne":
             self.format_string = "ffffHf"
-            self.index_intensity = 3
+            self.intensity_channel = 3
         else:
             print("[ERROR] Unsupported LiDAR Type")
             sys.exit()
@@ -94,7 +94,7 @@ class HeLiPRDataset:
 
         # Special case, see https://github.com/minwoo0611/HeLiPR-File-Player/blob/e8d95e390454ece1415ae9deb51515f63730c10a/src/ROSThread.cpp#L632
         if self.sequence_id == "Aeva" and int(Path(file_path).stem) <= 1691936557946849179:
-            self.index_intensity = None
+            self.intensity_channel = None
             format_string = self.format_string_no_intensity
         else:
             format_string = self.format_string
@@ -114,8 +114,8 @@ class HeLiPRDataset:
         points = data[:, :3]
         scan = self.o3d.geometry.PointCloud()
         scan.points = self.o3d.utility.Vector3dVector(points)
-        if self.index_intensity is not None:
-            intensity = data[:, self.index_intensity]
+        if self.intensity_channel is not None:
+            intensity = data[:, self.intensity_channel]
             intensity = (intensity - intensity.min()) / (intensity.max() - intensity.min())
             colors = self.cmap(intensity)[:, :3].reshape(-1, 3)
             scan.colors = self.o3d.utility.Vector3dVector(colors)


### PR DESCRIPTION
The loading is slow for HeLiPR, especially for the Aeva and Ouster data. Using Python's `struct` is a bit faster than `numpy`'s `from_file`. This improves the runtime from 3.8 Hz to 4.6 Hz for Aeva and from 2.4 Hz to 3.3 Hz for Ouster.