### PR TITLE
fix open3d tensor API access of pointcloud data

### DIFF
--- a/src/lidar_visualizer/datasets/generic.py
+++ b/src/lidar_visualizer/datasets/generic.py
@@ -117,7 +117,7 @@ class GenericDataset:
                     intensity = scan.point.intensity.numpy()
                     intensity = intensity / intensity.max()
                     colors = self.cmap(intensity)[:, :, :3].reshape(-1, 3)
-                    return np.asarray(scan.points), colors
+                    return scan.point.positions.numpy(), colors
 
                 # else
                 scan = scan.to_legacy()


### PR DESCRIPTION
There was an error when generic dataloader used the Open3D route to load PLY files, which was apparently a bug in the API access for the tensor version of open3d used in the dataloader.